### PR TITLE
clean up summer meeting notes

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,7 @@ on:
       hugoVersion:
         description: "Hugo Version"
         required: false
-        default: "0.126.3"
+        default: "0.127.0"
 
 # Allow one concurrent deployment
 concurrency:
@@ -36,7 +36,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: "0.126.3"
+      HUGO_VERSION: "0.127.0"
     steps:
       - name: Check version
         if: ${{ github.event.inputs.hugoVersion }}

--- a/content/posts/2023-02-17-codejam.md
+++ b/content/posts/2023-02-17-codejam.md
@@ -30,9 +30,9 @@ You can also participate remotely.
 
 # What
 
-Languages can be C/C++, Python, Java, and Javascript.
+Languages can be C/C++, Python, Java, and JavaScript.
 
-There will be a set of prompts to choose from that will be revealed on 12:00 am on April 1st. You code throughout the weekend and submit for judgement before 11:59 PM on Sunday.
+There will be a set of prompts to choose from that will be revealed on 12:00 am on April 1st. You code throughout the weekend and submit for judgment before 11:59 PM on Sunday.
 
 You can submit either a GitHub repo link or a zipped version of your files. Your submission will include at least a video or documentation of what your submission should do. Your project must be buildable on Windows; ensure you include build instructions. 
 

--- a/content/posts/2023-05-14-second-meeting.md
+++ b/content/posts/2023-05-14-second-meeting.md
@@ -15,19 +15,19 @@ tags = ['meeting', 'advisor', 'recruitment']
 
 ## Discussions
 
-- Re: Constitution; base general format on other club's constitution
+- Re: Constitution; base general format on other club's constitutions
     - Karl has started a [constitution repo](https://github.com/pwsdc/constitution)
 
 - Discussed adding second advisor
     - Must be PennWest faculty/staff
     - will be able to run club longer
-    - Dr. Kovalchik 
+    - Dr. Kovalchick 
     - in with CIS dept
 
 - Heavy recruitment during semester
-    - focus on freshman/sophmores
+    - focus on freshman/sophomores
 
-- Holding of on having GitHub as requirement for active membership; possibly just 2 meetings or even keeping at 1
+- Holding off on having GitHub as requirement for active membership; possibly just 2 meetings or even keeping at 1
   - workshops may help attract members
 
 - Continue teaching GitHub, have git workshops
@@ -39,7 +39,7 @@ tags = ['meeting', 'advisor', 'recruitment']
         - eg breakpoints, debugger, print statements
     - Makefiles
     - Rotate who creates workshop
-    - Javascript/Typescript
+    - JavaScript/TypeScript
     - Markdown
 
 - Ideas for new member recruitment

--- a/content/posts/2023-05-21-third-summer-meeting.md
+++ b/content/posts/2023-05-21-third-summer-meeting.md
@@ -29,7 +29,7 @@ We want to do workshops and presentations during the semester and coding topics.
 
 The following are some topics different officers may cover.
 
-- Christian: Code Styling, asp.net
+- Christian: Code Styling, ASP.NET
 - Luke: TypeScript
 - Karl: React, Git, Docker, Freeplane, Anki
 
@@ -43,11 +43,11 @@ We aren't sure how much we will get from SAI, but it may be from $100 to $200 do
 
 ### Discord Bot
 
-Karl is looking for collaborators and ideas for the discord bot. May do a summer workshop on it at some point.
+Karl is looking for collaborators and ideas for the Discord bot. May do a summer workshop on it at some point.
 
 ### PennWest CompSci Program
 
-We discussed some parts of the program that could use improvement. We think git/GitHub should be taught earlier and continously; it could be integrated into virtually all coding classes. It was one of the main technologies that industry professionals said they saw lacking in graduates. Christian thinks agile development could be taught more formally and earlier, though Karl thought it wasn't as important as Git/GitHub.
+We discussed some parts of the program that could use improvement. We think Git/GitHub should be taught earlier and continuously; it could be integrated into virtually all coding classes. It was one of the main technologies that industry professionals said they saw lacking in graduates. Christian thinks agile development could be taught more formally and earlier, though Karl thought it wasn't as important as Git/GitHub.
 
 ### Next Meeting
 
@@ -67,7 +67,7 @@ Ask if anyone has started prepping presentations, continue to decide what presen
 
 Is the calendar working for us? Are there other options?
 
-### Treasury follow up
+### Treasury Follow Up
 
 Christian is going to ask Jess about SAI and budgets. 
 
@@ -85,6 +85,6 @@ Christian is going to ask Jess about SAI and budgets.
 - Can we mention the winner on the website?
 - Move 2023 April Fools Jam to regular "Posts"?
 - Make a top-level page for the 2023 Fall Programming Club Pizza Party?
-- Creating content for the "About" page of the programming club?
+- Creating content for the "About" page of the Programming Club?
 
 Do we want to switch frameworks? React?

--- a/content/posts/2023-05-28-Lukes-First-Logos.md
+++ b/content/posts/2023-05-28-Lukes-First-Logos.md
@@ -75,13 +75,13 @@ Friday @ 5:00 PM (Voted 5-0)
 - Christian would be down to switch website framework to React or Angular
 - Karl still doesn't have appropriate Discord permissions
 
-# Agenda Next Meeitng
+# Agenda Next Meeting
 
 (very similar to last week)
 
 ### Logo and Rebranding
 
-Discuss the status of logo and rebranding.
+- Discuss the status of logo and rebranding.
 
 ### Presentations
 
@@ -92,7 +92,7 @@ Discuss the status of logo and rebranding.
 
 - Calendar working for us? Can someone be in charge of adding stuff to it?
 
-### Treasury follow up
+### Treasury Follow Up
 
 - Email from SAI
 

--- a/content/posts/2023-06-02-first-june-meeting.md
+++ b/content/posts/2023-06-02-first-june-meeting.md
@@ -24,12 +24,12 @@ tags = ['meeting', 'presentation', 'treasury']
 
 - Luke is interested in doing a presentation regarding booting from a Linux partition.
 - Christian is interested in doing a test-driven-development presentation.
-- A VSCodium or VSCode presentation could be good.
+- A VSCodium or VS Code presentation could be good.
 
 ### Docker Presentation
 
 - The Docker presentation Karl did was well received.
-- If we were to add a Docker setup to the example repo, C#/asp.net was suggested for a few reasons:
+- If we were to add a Docker setup to the example repo, C#/ASP.NET was suggested for a few reasons:
     1. It ties nicely into the C based curriculum at PennWest
     2. A lot of employers seem to want it
     3. It's a nice language
@@ -51,11 +51,11 @@ tags = ['meeting', 'presentation', 'treasury']
 - People could contribute front end designs
 - Anyone interested in the website will meet on Thursday @5:00 PM to talk about stacks and technologies
 
-_Note_: The website repo is started. It's a React app. Check out [the repo here](https://github.com/pwsdc/new-website). Contributions welcome.
+_Note_: The website repo is started. It's a React app. Check out [the repo here](https://github.com/pwsdc/new-website). Contributions are welcome.
 
 We know we want to make sure the website can still support content in markdown format.
 
-# Agenda Next Meeitng
+# Agenda Next Meeting
 
 ### Game Club Game Jam
 

--- a/content/posts/2023-06-10-game-jam.md
+++ b/content/posts/2023-06-10-game-jam.md
@@ -45,10 +45,10 @@ Karl still needs to follow up on SAI. (Phone call)
 
 # Votes
 
-We voted to clean up the discord in several ways:
+We voted to clean up the Discord in several ways:
 
 - 4-0 (aye) to rename #rust to #other-languages
-- 4-0 (aye) to move #gaming-projects to officer-archive
+- 4-0 (aye) to move #gaming-projects to officer archive
 - 4-0 (aye) to move #club-code-jam-projects to officer archive
 - 4-0( aye) to move #team-projects to officer archive
 - 4-0 (aye) to move #merch-channel to officer archive

--- a/content/posts/2023-06-24-8th-summer-meeting.md
+++ b/content/posts/2023-06-24-8th-summer-meeting.md
@@ -71,7 +71,7 @@ tags = ['meeting', 'sai', 'schedule', 'events', 'merch', 'logo', 'advisor']
 - We tend to like Software Development Club
 - It's currently "Computer Programming Club"
 
-## Talk to Dr. Kovalchik
+## Talk to Dr. Kovalchick
 
 - Could help with promoting the club with CIS
 - We could ask her to be the 2nd faculty advisor

--- a/content/posts/2023-08-12-15th-summer-meeting.md
+++ b/content/posts/2023-08-12-15th-summer-meeting.md
@@ -61,7 +61,7 @@ We applied the new logo and redid the server name.
 - Motion to adopt logo, unofficially rename club (4-0)
 - Motion to set meeting time to 11:00 AM on Thursdays this semester (4-0)
 
-# Agenda Next meeting
+# Agenda Next Meeting
 
 - Renaming GitHub
 - Renaming Website

--- a/content/posts/2023-08-24-1st-fall-meeting.md
+++ b/content/posts/2023-08-24-1st-fall-meeting.md
@@ -8,7 +8,7 @@ tags = ['introduction', 'elections', 'suggestions', 'content']
 
 # Attendance
 
-*Note: If we mispelled any names or didn't get your last name, our apologies, please let us know. We will also try to get it next meeting.*
+*Note: If we misspelled any names or didn't get your last name, our apologies, please let us know. We will also try to get it next meeting.*
 
 - Karl Miller
 - Luke Bates

--- a/content/posts/2023-08-31-2nd-fall-meeting.md
+++ b/content/posts/2023-08-31-2nd-fall-meeting.md
@@ -8,7 +8,7 @@ tags = ['introduction', 'elections', 'suggestions', 'content']
 
 # Discussions
 
-- Enjoyed a pizza party
+- Enjoyed a pizza party.
 - Talked about primary projects for the club (game or application) to focus on. Robert opened a Google Forms post on the Discord server. Club members were given the chance to provide ideas for this project.
 - Members were reminded that formal election for officers will be held at the end of this semester.
 - We need ideas for merchandise (hats or mouse pads)?

--- a/content/posts/2023-09-07-3rd-fall-meeting-github-presentation.md
+++ b/content/posts/2023-09-07-3rd-fall-meeting-github-presentation.md
@@ -73,7 +73,7 @@ Upload your local changes to GitHub. **Ensure your local repository is connected
 
 ## Git Integration with VS Code
 
-- When you open VS code, focus on the left-most panel. There should be an icon for "**source control**" (The icon resembles a tree with nodes).
+- When you open VS Code, focus on the left-most panel. There should be an icon for "**source control**" (The icon resembles a tree with nodes).
 - The GUI will provide ways to initialize Git, add untracked files, commit changes, and push commits.
 - The GUI is much more user friendly, but the console is much more powerful.
 

--- a/content/posts/2023-09-14-club-fair.md
+++ b/content/posts/2023-09-14-club-fair.md
@@ -37,11 +37,11 @@ Karl talked to Austin from the Finance Club about Quant analysis. He was interes
 
 ## Career Center
 
-Karl spoke with Rhonda Gifford from the career center. Getting Erie Insurance to speak to the club is still in the pipeline. We might also have an in at Highmark. We might also be able to have Kristen Doppelhauer speak to the club about resume creation and job search, and/or Meghan Clister speak about getting internships. A lot of our members are interested in internships and Karl thinks it's a good idea to get some more exposure through these avenues.
+Karl spoke with Rhonda Gifford from the career center. Getting Erie Insurance to speak to the club is still in the pipeline. We might also have an in at Highmark. We might also be able to have Krissie Doppelheuer speak to the club about resume creation and job search, and/or Meaghan Clister speak about getting internships. A lot of our members are interested in internships and Karl thinks it's a good idea to get some more exposure through these avenues.
 
 ## Jakob
 
-Jakob, a CIS student, who has attended our meetings, and who has been working on launching a monetized AI app, is willing to talk to the club about his experiences with entrepeneurship. He's also willing to give out free access to his app in exchange for Quality Assurance. (bug finding)
+Jakob, a CIS student, who has attended our meetings, and who has been working on launching a monetized AI app, is willing to talk to the club about his experiences with entrepreneurship. He's also willing to give out free access to his app in exchange for Quality Assurance. (bug finding)
 
 ## Radio
 

--- a/content/posts/2023-12-15-first-winter-meeting.md
+++ b/content/posts/2023-12-15-first-winter-meeting.md
@@ -11,7 +11,7 @@ tags = ['presentation']
 # Overview
 
 - Attendance
-- Academic Calendar Overview
+- Academic Calendar/Meetings Overview
 - Next Week
 
 ***

--- a/content/posts/2023-12-28-second-winter-meeting.md
+++ b/content/posts/2023-12-28-second-winter-meeting.md
@@ -25,7 +25,7 @@ tags = ['presentation']
 - Lavender Wilson
 - Jonathan Buckel (for the last few minutes)
 
-## Finalizing Plans
+## Finalizing Meeting Plans
 
 Christian's ideas:
 - Making the most out of your internship

--- a/content/posts/2024-01-04-third-winter-meeting.md
+++ b/content/posts/2024-01-04-third-winter-meeting.md
@@ -13,7 +13,7 @@ tags = ['meeting', 'presentation', 'schedule']
 - Attendance
 - Room Details
 - First Week Meeting
-- Club/Organization Fair
+- Club Fair
 - Commuters
 - Coding Competition
 - Club Project Attempts

--- a/content/posts/2024-01-18-first-spring-meeting.md
+++ b/content/posts/2024-01-18-first-spring-meeting.md
@@ -13,10 +13,10 @@ tags = ['meeting', 'presentation', 'git']
 - Attendance
 - Git/GitHub Presentation
 	- What is Git/GitHub?
-	- Using Git
+	- Using Git (via Terminal)
 	- Using GitHub
 	- Actually Using GitHub
-	- Group work
+	- Group Work: Forks, Pull Requests, and Merge Conflicts
 	- Gitignore
 - Next Week
 
@@ -35,7 +35,7 @@ tags = ['meeting', 'presentation', 'git']
 
 ## GitHub Presentation
 
-### Git/GitHub
+### What is Git/GitHub?
 
 At its core, Git is version control software. To install: 
 - Go to [the download link](https://git-scm.com) and follow the instructions
@@ -62,9 +62,9 @@ If your local repo is behind your remote one, you can sync your local one up to 
 
 ### Actually Using GitHub
 
-Chances are very high that you will rarely actually use the command line to do all your version control; the vast majority of IDEs have integrated git capabilites, and you'll use it through those (it's much easier). All the concepts are still the same (with adding, committing, pushing, pulling, etc.), but most of them will use a more visual representation (and they look nicer). 
+Chances are very high that you will rarely actually use the command line to do all your version control; the vast majority of IDEs have integrated git capabilities, and you'll use it through those (it's much easier). All the concepts are still the same (with adding, committing, pushing, pulling, etc.), but most of them will use a more visual representation (and they look nicer). 
 
-### Group work: Forks, Pull Requests, and Merge Conflicts
+### Group Work: Forks, Pull Requests, and Merge Conflicts
 
 A __fork__ is a personal copy of any repository. The fork is where all your local changes will be saved when you push changes from your local repo. It is very bad practice to upload your changes straight to the master branch; always push to your fork first, and then merge them later, once you've confirmed everything is as intended. 
 
@@ -94,4 +94,4 @@ Generally, dependencies take up a lot of space. These should be specified in you
 
 ## Next Week
 
-Next Thursday is the Club & Org fair; We will still have a meeting, but Christian and Lavender will be at the club fair to promote the club. The meeting will be a more relaxed meeting with LeetCode problems. 
+Next Thursday is the Club & Org fair; we will still have a meeting, but Christian and Lavender will be at the club fair to promote the club. The meeting will be more relaxed with LeetCode problems. 

--- a/content/posts/2024-01-25-second-spring-meeting.md
+++ b/content/posts/2024-01-25-second-spring-meeting.md
@@ -11,7 +11,7 @@ tags = ['meeting', 'code jam', 'leetcode']
 # Overview
 
 - Attendance
-- Announcements from club advisor
+- Announcements from Club Advisor
 - LeetCode Problems
 - Next Week
 
@@ -29,21 +29,19 @@ tags = ['meeting', 'code jam', 'leetcode']
 - Christian Messmer (at club fair)
 - Lavender Wilson (at club fair)
 
-## Announcements from club advisor
+## Announcements from Club Advisor
 
 The advisor for the Software Development Club (Dr. Menon) brought forward a few opportunities for events that our club could participate in.
 
 ### Pacise Programming Conference
 
-A programming contest will be held from April 5th - April 6th, 2024. If we want to particpate, we will need to allocate funds for travel expenses. The advisor indicated that she will look into determining the steps that we would need to take to prepare if we are interested.
+A programming contest will be held from April 5th - April 6th, 2024. If we want to participate, we will need to allocate funds for travel expenses. The advisor indicated that she will look into determining the steps that we would need to take to prepare if we are interested.
 
 ### Strike-a-Spark
 
 This event will be held at PennWest on April 17th, 2024. The advisor suggested that the students within the club who are in a Senior Project course could complete a poster to present their projects. Funding may need to be allocated for materials to complete poster presentations.
 
 ## LeetCode Problems
-
-### LeetCode
 
 The following LeetCode problems were covered during the meeting:
 - [Fizz Buzz](https://leetcode.com/problems/fizz-buzz/description/)

--- a/content/posts/2024-02-01-third-spring-meeting.md
+++ b/content/posts/2024-02-01-third-spring-meeting.md
@@ -17,7 +17,7 @@ tags = ['meeting', 'presentation', 'malware']
 	- Viruses
 	- Worms
 	- Ransomware
-	- History of Antivirus
+	- Brief History of Antivirus
 	- How is Malware Made?
 	- How to Protect Yourself
 - Next Week
@@ -38,11 +38,11 @@ tags = ['meeting', 'presentation', 'malware']
 - Zach Teixido
 - Zullikha Hassan
 
-## Malware
+## Malware Presentation
 
 ### What is Malware?
 
-Malware stands for "malicious software," and refers to any software that is harmful or intrusive. 
+Malware stands for "malicious software", and refers to any software that is harmful or intrusive. 
 Malware:
 - Has been around since the beginning of computing
 - Early malware had a style reminiscent of the demoscene
@@ -51,12 +51,12 @@ Malware:
 
 ### Types of Malware
 
-- __Virus__: Code that copies itself into other files and programs, allowing it to spread.
-- __Worm__: Similar to a virus, but can spread without the need of a human to enable it. 
-- __Ransomware__: Software that encrypts your data and demands payment as a ransom.
-- __Adware__: Displays unwanted advertisements.
-- __Spyware__: Gathers information about the user unknowingly.
-- __Rootkit__: Hides the existence of malware in a system.
+- __Virus__: Code that copies itself into other files and programs, allowing it to spread
+- __Worm__: Similar to a virus, but can spread without the need of a human to enable it.
+- __Ransomware__: Software that encrypts your data and demands payment as a ransom
+- __Adware__: Displays unwanted advertisements
+- __Spyware__: Gathers information about the user unknowingly
+- __Rootkit__: Hides the existence of malware in a system
 
 People tend to assume that malware will always destroy your computer; while they can, generally they pursue more nefarious means (such as stealing data or holding a system for ransom). 
 

--- a/content/posts/2024-02-08-fourth-spring-meeting.md
+++ b/content/posts/2024-02-08-fourth-spring-meeting.md
@@ -27,7 +27,7 @@ tags = ['meeting', 'presentation', 'resume', 'internship']
 
 ## Resume/Internships Presentation
 
-We plan to have someone from the Career Center have a presentation and a resume workshop on the 29th this month. Plan to have a resume available to review for a workshop (a good source is [resumake](resumake.io))
+We plan to have someone from the Career Center have a presentation and a resume workshop on the 29th this month. Plan to have a resume available to review for a workshop (a good source is [Resumake](https://resumake.io)).
 
 Nowadays, resumes are a little different than they used to be. Companies are now getting resumes from all over the world for any roles they post. Because there are just way too many resumes to go through by hand, they use bots to really quickly narrow down the amount of resumes to something manageable by hand.
 

--- a/content/posts/2024-02-15-fifth-spring-meeting.md
+++ b/content/posts/2024-02-15-fifth-spring-meeting.md
@@ -29,7 +29,7 @@ tags = ['meeting', 'Dev-C++', 'C-C++', 'IDE', 'VS Code']
 
 ### What is Dev-C++?
 
-Dev C++ is an IDE for the C and C++ programming languages. It was originally released in 1998 and has had several forks since. This IDE is recommended by the professors on campus.
+Dev-C++ is an IDE for the C and C++ programming languages. It was originally released in 1998 and has had several forks since. This IDE is recommended by the professors on campus.
 
 ### Benefits of Dev-C++
 
@@ -41,7 +41,7 @@ It is VERY outdated. This IDE is lacking:
 - Version control integration
 - Syntax highlighting
 - Meaningful extensions
-- Comprenhensive code completion 
+- Comprehensive code completion 
 - Features and refinements from newer GCC compilers
 
 ### Dev-C++ is LITERALLY broken!
@@ -67,7 +67,7 @@ The easiest way to compile C/C++ programs is with a Makefile. To install make us
 ### Need an IDE?
 
 * [Visual Studio](https://visualstudio.microsoft.com/downloads/)
-* [Jetbrains CLion](https://www.jetbrains.com/clion/) 
+* [JetBrains CLion](https://www.jetbrains.com/clion/) 
     * This IDE is paid, but it can be accessed for free with the GitHub student pack.
 * [Code::Blocks](https://www.codeblocks.org/downloads/) 
     * This has a lot of the same problems as Dev-C++, but it does not delete your code!

--- a/content/posts/2024-02-22-sixth-spring-meeting.md
+++ b/content/posts/2024-02-22-sixth-spring-meeting.md
@@ -25,7 +25,7 @@ tags = ['meeting', 'leetcode']
 - Paul Shriner
 - Zachary Teixido
 
-## LeetCode
+## LeetCode Problems
 
 Today we went over two LeetCode problems: #55 ("Jump Game") [here](https://leetcode.com/problems/jump-game/), as well as #45 ("Jump Game II") [here](https://leetcode.com/problems/jump-game-ii/).
 

--- a/content/posts/2024-03-14-eighth-spring-meeting.md
+++ b/content/posts/2024-03-14-eighth-spring-meeting.md
@@ -9,7 +9,7 @@ tags = ['meeting', 'presentation', 'academics', 'git', 'Dev-C++', 'ide', 'VS Cod
 # Overview
 - Attendance
 - Why You Should Try C#
-- PennWest Adoption of Git and VSCode
+- PennWest Adoption of Git and VS Code
 ***
 ## Attendance
 - Abu Shettima
@@ -31,7 +31,7 @@ tags = ['meeting', 'presentation', 'academics', 'git', 'Dev-C++', 'ide', 'VS Cod
 - Essentially the same as JRE
 - Currently up to .NET Core 8, .NET 4 in LTS (long-term support)
 ### Why Should You Use It?
-- It's a very general purpose OOP lanugage
+- It's a very general purpose OOP language
 - Supports implicitly typed variables (`var` keyword)
 - Has massive support for many libraries with package manager
 - Supports strong structure using namespaces
@@ -50,8 +50,8 @@ namespace DTC.Model {
 }
 ```
 
-# Git and VSCode adoption
-We discussed inviting several professors to a club meeting in order to convince them to advocate for teaching students how to use Git (and maybe GitHub or another online repo storage provider), as well as adopting VSCode (instead of Dev-C++) as the primary text editor that students use. 
+# PennWest Adoption of Git and VS Code
+We discussed inviting several professors to a club meeting in order to convince them to advocate for teaching students how to use Git (and maybe GitHub or another online repo storage provider), as well as adopting VS Code (instead of Dev-C++) as the primary text editor that students use. 
 
 There are so many benefits of making these changes, and not implementing them keeps current students in the past in terms of what software/technology they'll actually be using once they get a job. 
 

--- a/content/posts/2024-03-21-ninth-spring-meeting.md
+++ b/content/posts/2024-03-21-ninth-spring-meeting.md
@@ -50,7 +50,7 @@ The solution presented in the video is to go "old-school", by actually communica
 
 ### Dr. Menon's Recommendation
 
-Our advisor, Dr. Menon, recommeneded taking a course in Generative AI. She feels it is more beneficial to learn and adapt to it, rather than trying to fight it. We will post links to Generative AI courses in the Club Discord.
+Our advisor, Dr. Menon, recommended taking a course in Generative AI. She feels it is more beneficial to learn and adapt to it, rather than trying to fight it. We will post links to Generative AI courses in the Club Discord.
 
 ## Next Week
 

--- a/content/posts/2024-03-28-tenth-spring-meeting.md
+++ b/content/posts/2024-03-28-tenth-spring-meeting.md
@@ -8,7 +8,7 @@ tags = ['presentation', 'internship', 'career', 'recruitment']
 ***
 # Overview
 - Attendance
-- Presentation
+- IT Audit Division Presentation
 ***
 ## Attendance
 - Abu Shettima
@@ -22,14 +22,14 @@ tags = ['presentation', 'internship', 'career', 'recruitment']
 - Tim DeFoor, PA's 52nd elected Auditor General and the first African American Auditor General in the state's history
 - Auditor General has been the Commonwealth's fiscal watchdog since 1810, responsible for ensuring that taxpayer dollars are spent legally and properly
 - Mission: to serve the people of Pennsylvania by improving government accountability, transparency, and the effective use of taxpayer dollars
-### Audit Reponsibilites
+### Audit Responsibilities
 4 types:
 - Financial Audits
 - Performance Audits
 - Attestation Audits
 - Compliance Audits
 ### Internship and Employment Opportunities
-- Gain Hands-on experience in Commonwealth auditing functions
+- Gain hands-on experience in Commonwealth auditing functions
 - Earn $16.86/hr, while making a difference
 - Opportunity to secure full-time employment & a rewarding career in public service
 
@@ -37,7 +37,7 @@ Sophomores and beyond are capable of applying. Their program is called the "Inte
 
 They want you to be minimally qualified (at least 2.5 GPA), and be good at looking at details and at numbers. After being accepted into an internship, you can complete 900 hours on your own time and then they can extend a full-time offer to you once you graduate. 
 
-They emphasize that the schedule is very flexible; the mentor will walk you through basic daily activities (such as putting in time sheets, recording your activites). The IT audit division is completely remote (except for giving presentations like they did today). The process from going from an intern to a full-time employee was easy (for Austin, another speaker). They treat interns more like full employees, and the work-life balance for full-time employees is good. 
+They emphasize that the schedule is very flexible; the mentor will walk you through basic daily activities (such as putting in time sheets, recording your activities). The IT audit division is completely remote (except for giving presentations like they did today). The process from going from an intern to a full-time employee was easy (for Austin, another speaker). They treat interns more like full employees, and the work-life balance for full-time employees is good. 
 ### Careers
 - Pay increases, incentive programs
 - Flexible schedules, work from home options
@@ -61,10 +61,10 @@ She started almost exactly one year ago; she applied late December of 2022; she 
 **Q:** Do you have to submit separate applications for different bureaus?  
 **A:** There are two application links that are live currently. There are 2 links on [the PA Auditor General website](https://www.paauditor.gov/careers); you can apply to both, but after your application is screened, you are eligible for any bureau. 
 
-**Q:** What are some technical skills or experiences that students need?  
+**Q:** What are some technical skills or experience that students need?  
 **A:** From an entry-level perspective, you just need to be minimally qualified. You don't need to be any specific major, you only need just 12 credits in any of the related fields. A basic Excel and Word knowledge is enough, as well as other Microsoft Suite applications. Written communication is very important, sometimes more important than the rest of the work.
 
-**Q:** How difficult is it as a senior to do the Intern 2 Hire progam?  
+**Q:** How difficult is it as a senior to do the Intern 2 Hire program?  
 **A:** You do have to essentially become a full-time employee to get at the 900 hour requirement, although you can do a lot of it during the summer, and that's why there are three months post-graduation to complete them. 
 
 **Q:** In general, how many people are hired (for internships and full-time employees)?  

--- a/content/posts/2024-04-04-eleventh-spring-meeting.md
+++ b/content/posts/2024-04-04-eleventh-spring-meeting.md
@@ -10,7 +10,8 @@ tags = ['IDE',  'events', 'elections']
 - Attendance
 - What is a good IDE?
 - General Discussion
-- Next week
+- Next Week
+***
 
 ## Attendance
 - Abu Shettima
@@ -22,12 +23,12 @@ tags = ['IDE',  'events', 'elections']
 
 ## What is a good IDE?
 ### Crimson Editor
-- The problem with this editor is that it is old and not widely used.
-- However, that does not necessarily make it a bad choice if someone needs a text editor.
+- The problem with this editor is that it is old and not widely used
+- However, that does not necessarily make it a bad choice if someone needs a text editor
 ### Dev C++
-- One should never use this IDE! We had a [previous meeting](/posts/2024-02-15-fifth-spring-meeting) dedicated to discussing the drawbacks to using this IDE.
+- One should never use this IDE! We had a [previous meeting](/posts/2024-02-15-fifth-spring-meeting) dedicated to discussing the drawbacks to using this IDE
 ### Visual Studio
-- This option is an actual IDE that contains debugging and performance checking tools.
+- This option is an actual IDE that contains debugging and performance checking tools
 - Has built-in C# and Nuget support
 - Recommended in Assembly and Cobol courses at PennWest California
 - However, this IDE does contain a significant learning curve
@@ -35,17 +36,17 @@ tags = ['IDE',  'events', 'elections']
 - These are both lightweight code editors
 - While they are technically not IDEs, they are fully customizable with a high plugin availability
 - These are popular editors with plenty of support and documentation
-- Similarly to Visual Studio, these editors contain a learning curve. However, it is not as significant.
+- Similarly to Visual Studio, these editors contain a learning curve. However, it is not as significant
 - NeoVim is slightly faster than Vim
 ### Xcode
 - Contains built-in Swift support
-- Has native support with modern Apple architecture. 
+- Has native support with modern Apple architecture
 - Easy compiling for macOS and iOS devices
 - Supports LSP and other plugins
 ### Notepad ++
 - Lightweight text editor
 - Similarly to VSCode, this is not technically an IDE
-- Unlike VSCode, this does not have support for most plugins.
+- Unlike VSCode, this does not have support for most plugins
 - However, it has macro capabilities and autocomplete (naive complete without LSP)
 ## General Takeaway
 Overall, one should pick an IDE that is modern and widely used.
@@ -60,5 +61,5 @@ Overall, one should pick an IDE that is modern and widely used.
 - A goal for next year is to recruit Freshman students. We should work towards helping them with any problems they are facing in lower-level classes.
 - Discussed ways to navigate group dynamics in programming classes. Before a single line of code is written, make a plan! Think of all functions in advance and determine what they do and what parameters they take in. That way, functions can be distributed amongst group members and they will not have to worry about whether or not the other ones actually exist yet.
 
-## Next week
+## Next Week
 - Next week, we will be having a meeting on Thursday at 11 AM in Eberly 342.

--- a/content/posts/2024-04-11-twelfth-spring-meeting.md
+++ b/content/posts/2024-04-11-twelfth-spring-meeting.md
@@ -48,7 +48,7 @@ This exact scenario must be met in order for this vulnerability to be exploited 
 This is a lesson in input: you should _always_ sanitize input from your user.
 
 ### Next Semester Meeting Times
-Since most of our core members were here for the meeting, we wanted to figure out what times/days would be good now that Common Hour is gone.
+Since most of our core members were here for the meeting, we wanted to figure out what times/days would be good now that common hour is gone.
 
 We decided that it would currently be best to meet on __Tuesdays__ from __5-6__, both in-person (most likely the same as usual, __Eberly 342__), as well as including online users who can't make it there in person. This decision, however, is not set in stone and may change. 
 

--- a/content/posts/2024-04-18-thirteenth-spring-meeting.md
+++ b/content/posts/2024-04-18-thirteenth-spring-meeting.md
@@ -29,7 +29,7 @@ All positions except Secretary were uncontested; here are the results from elect
 - Secretary: Lavender Wilson
 ## Club Direction
 We discussed what kinds of things that we want the club to be for. Some items that were mentioned:
-- Having some small supplimental instruction (eg. Git/Github)
+- Having some small supplemental instruction (eg. Git/GitHub)
 - Providing help for specific courses
 - Sharing personal projects and collaboration
 - Branching out a little bit to related topics (such as watching movies or playing games)

--- a/content/posts/2024-04-25-fourteenth-spring-meeting.md
+++ b/content/posts/2024-04-25-fourteenth-spring-meeting.md
@@ -21,7 +21,7 @@ tags = ['meeting', 'presentation', 'senior project']
 - Matthew Williams
 - Paul Shriner
 - Luke Vukovich
-## Senior Projects
+## Senior Project Presentations
 Two groups quickly presented their senior project slides to the club.
 ### DeckTechCentral
 DTC is a Magic: The Gathering deck list management system. It aims to allow experienced players to build their own decks.

--- a/content/posts/2024-05-05-first-summer-2024-meeting.md
+++ b/content/posts/2024-05-05-first-summer-2024-meeting.md
@@ -3,7 +3,7 @@ title = '1st Summer 2024 Meeting'
 date = 2024-05-05T21:50:46-04:00
 draft = false
 summary = 'club meeting, plans going forward'
-tags = ['meeting', 'constitution', 'presentation']
+tags = ['meeting', 'constitution', 'presentation', 'discord', 'advisor']
 +++
 
 ***
@@ -58,4 +58,6 @@ Dr. Menon reached out to us about having CIS students present various topics in 
 
 ## Next Meeting
 
-We aim to do a meeting on Saturday May 11, 2024 at 7 PM. An announcement along with a meeting agenda will be posted closer to the meeting date. Currently, we aim to discuss the constitution articles we looked into, any feedback we've received from reaching out to people, and a meeting time for the fall semester.
+We aim to do a meeting on **Saturday May 11, 2024** at **7 PM**, anyone is welcome to join!
+
+Currently, we plan to discuss the constitution articles we looked into, any feedback we've received from reaching out to people, and a meeting time for the fall semester.

--- a/content/posts/2024-05-05-first-summer-2024-meeting.md
+++ b/content/posts/2024-05-05-first-summer-2024-meeting.md
@@ -28,11 +28,11 @@ tags = ['meeting', 'constitution', 'presentation', 'discord', 'advisor']
 
 ## What are Summer Meetings?
 
-We will be holding summer meetings so the officers can prepare for the fall semester and so anyone can join and hang out. For each meeting, we will have an agenda to follow. Once we're done with items on the agenda, the floor will be open for anyone to present anything (such as personal projects, internships, or just something interesting). This specifc meeting was more "off the cuff", we will aim to have more structured meetings going forward.
+We will be holding summer meetings so the officers can prepare for the fall semester and so anyone can join and hang out. For each meeting, we will have an agenda to follow. Once we're done with items on the agenda, the floor will be open for anyone to present anything (such as personal projects, internships, or just something interesting). This specific meeting was more "off the cuff", we will aim to have more structured meetings going forward.
 
 ## Constitution
 
-The current club constitution has not been updated for a long time and needs major improvements. We are aiming to overhual the constitution during the summer.
+The current club constitution has not been updated for a long time and needs major improvements. We are aiming to overhaul the constitution during the summer.
 
 Our first step is to understand what's in the current constitution. We feel it would be reckless to try to make changes if all the officers do not have a thorough understanding of its current state. 
 

--- a/content/posts/2024-05-13-second-summer-meeting.md
+++ b/content/posts/2024-05-13-second-summer-meeting.md
@@ -33,11 +33,11 @@ From now on, we'll have 1-2 main discussion topics, followed by more scattered/u
 
 # Constitution
 
-Last week, some of our officers looked at certain sections of our constitution for potential adjustments. Some of the sections were relatively simple/less important, and so were skipped.
+Last week, some of our officers looked at sections of our constitution for potential adjustments. Some of the sections were relatively simple/less important, and so were skipped.
 
 Separately, Christian recommends that we focus on only changing the name of the club on the constitution, and instead putting our time towards more important topics (such as gaining members in the near future). 
 
-He also mentioned that, so long as nobody commits any kind of fraud, PennWest does not really enforce club's constitutions very much, especially for smaller clubs.
+He also mentioned that, so long as nobody commits any kind of fraud, PennWest does not really enforce club constitutions very much, especially for smaller clubs.
 
 ## Article 4 - Officers
 
@@ -88,4 +88,4 @@ We want to be more prepared for the next club fair(s), but since they are still 
 
 Next week, we'll be focusing much more on general strategies to gain new members. 
 
-Our next meeting will be on **Monday, May 20th** at **8:30 PM**. 
+Our next meeting will be on **Monday, May 20th** at **8:30 PM**, feel free to drop by!

--- a/content/posts/2024-05-13-second-summer-meeting.md
+++ b/content/posts/2024-05-13-second-summer-meeting.md
@@ -7,15 +7,19 @@ tags = ['meeting', 'advisor', 'club-fair', 'constitution', 'schedule']
 +++
 
 ***
+
 # Overview
+
 - Attendance
 - General Meeting Agendas
 - Constitution
 - Unguided Discussions
 - Next Meeting
+
 ***
 
 # Attendance
+
 - Abu Shettima
 - Christian Messmer
 - Lavender Wilson
@@ -24,33 +28,64 @@ tags = ['meeting', 'advisor', 'club-fair', 'constitution', 'schedule']
 - Rob Krency
 
 # Meeting Agendas
-Starting from this meeting, we'll be following the general format of having one or two main discussion topics, and then afterwards dispersing into more scattered/unrelated discussion topics.
+
+From now on, we'll have 1-2 main discussion topics, followed by more scattered/unrelated dscussions.
 
 # Constitution
-Last week, some of our officers looked at certain sections of our constitution, analyzing and then determining if anything should be adjusted. Some of the sections were relatively simple/less important, and so were skipped.
-Separately, Christian recommends that we focus on only changing the name of the club on the constitution, and instead putting our time towards more important topics (such as gaining members in the near future). He also mentioned that, so long as nobody commits any kind of fraud, PennWest does not really enforce club's constitutions very much, especially for smaller clubs.
+
+Last week, some of our officers looked at certain sections of our constitution for potential adjustments. Some of the sections were relatively simple/less important, and so were skipped.
+
+Separately, Christian recommends that we focus on only changing the name of the club on the constitution, and instead putting our time towards more important topics (such as gaining members in the near future). 
+
+He also mentioned that, so long as nobody commits any kind of fraud, PennWest does not really enforce club's constitutions very much, especially for smaller clubs.
 
 ## Article 4 - Officers
-This article details (or, rather, makes a general description of) the roles, powers, and responsibilities/duties of each of the officers. Discussion turned towards the information not being very descriptive and leaning more towards vagueness (a trend that we noticed throughout the constitution), as well as that our club has not been doing much budget-wise recently. 
+
+- Details (through a general description) the roles, powers, and responsibilities/duties of each of the officers.
+- This information was not very descriptive, instead leaning more towards vagueness (a trend we noticed throughout the constitution).
+- Our club has not been doing much budget-wise recently.
 
 ## Article 5 - Removal
-This section describes how officers may be removed, given that they "fail to perform \[their\] duties." This section is much shorter than we decided it ought to be, and is missing a lot of pertinent information. We intend to expand upon the general scenarios where a vote may be called to remove an officer, as well as expanding upon the process of removal to include a chance for the offending officer to form a rebuttal. 
+
+- Describes how officers may be removed, given that they “fail to perform \[their\] duties.”
+- This section is way too short and missing pertinent information.
+- We intend to expand upon the general scenarios where a vote may be called to remove an officer.
+- The process of removal should include a chance for the offending officer to form a rebuttal. 
 
 ## Article 6 - Meetings
-This section is about the weekly meetings. While vague, this section serves its purpose and leaves flexibility to the officers to decide the rest of the meeting details. We decided that it was likely for the better, especially now that common hour is gone and we need to be more flexible. 
 
-## Article 7 - Quorum
-This article details the number/amount of members and officers that must be present in order for a club meeting to take place. It is currently set at 50% of active members with at least 2 officers. We tend to have all 4 officers, and since we have a relatively small active member pool, the 50% minimum is met more often than not. 
+- About the weekly meetings.
+- While vague, it does serve its purpose and leaves flexibility to decide the rest of the meeting details.
+- Now that common hour is gone, this is likely for the better.
+
+## Article 7 - Quorum 
+
+- Details the number/amount of members and officers that must be present in order for a club meeting to take place.
+- Currently set at 50% of active members with at least 2 officers.
+- We tend to have all 4 officers, and since we have a relatively small active member pool, the 50% minimum is met more often than not.
 
 ## Article 8 - Advisor
-This article discusses information surrounding the advisor. We wanted to add that there may be multiple advisors and be more specific about what the advisor should do. We also made note that we currently do not make very much use of our advisor, so reaching out to her for general advice would be a good option. 
+
+- Discusses information surrounding the advisor.
+- We want to be more specific about the advisor's roles and the possibility of multiple advisors.
+- We also noted that we currently do not make very much use of our advisor; we should reach out to her more for general advice.
 
 # Unguided Discussions
+
 ## Fall Meeting Times
-As most of us know, most clubs will need to think about new meeting times for club meetings since the common hour was removed. We have previously discussed having in-person and/or hybrid meetings later in the day, most likely on a Tuesday, a Thursday, or maybe both. We plan to have the meetings in the same room as usual, though we discussed potentially having a different room than usual (both because Eberly may not be available later in the day as well as that students may not want to come to club meetings in the same room as their other classes). 
+
+Most clubs will need to think about new meeting times for club meetings since common hour was removed (us included). We have previously discussed having in-person and/or hybrid meetings later in the day, most likely on a Tuesday, a Thursday, or maybe both.
+
+We plan to have the meetings in the same room as usual, though we discussed potentially having a different room (both because Eberly may not be available later in the day as well as that students may not want to come to club meetings in the same room as their other classes). 
 
 ## Club Fair
-We discussed some aspects of the club fair, since it pertains to gaining members. We primarily recalled our past few experiences at club fairs, which did not go very well (only getting the interest of about 1 or 2 people each time, and not having much to show off). We want to be more prepared for the next club fair(s), but since they are still a ways away, we decided to discuss strategies and preparation details in a later meeting -- likely coming up naturally from discussing plans to increase membership. 
+
+We discussed some aspects of the club fair, since it pertains to gaining members. We primarily recalled our past few experiences at club fairs, which did not go very well (only getting the interest of about 1 or 2 people each time, and not having much to show off). 
+
+We want to be more prepared for the next club fair(s), but since they are still a ways away, we decided to discuss strategies and preparation details in a later meeting -- likely coming up naturally from discussing plans to increase membership. 
 
 # Next Meeting
-Next week, we'll be focusing much more on general strategies to gain new members. We'll be having our next meeting at the same time next week (8:30 PM on Monday, May 20th). 
+
+Next week, we'll be focusing much more on general strategies to gain new members. 
+
+Our next meeting will be on **Monday, May 20th** at **8:30 PM**. 

--- a/content/posts/2024-05-13-second-summer-meeting.md
+++ b/content/posts/2024-05-13-second-summer-meeting.md
@@ -29,7 +29,7 @@ tags = ['meeting', 'advisor', 'club-fair', 'constitution', 'schedule']
 
 # Meeting Agendas
 
-From now on, we'll have 1-2 main discussion topics, followed by more scattered/unrelated dscussions.
+From now on, we'll have 1-2 main discussion topics, followed by more scattered/unrelated discussions.
 
 # Constitution
 

--- a/content/posts/2024-05-20-third-summer-meeting.md
+++ b/content/posts/2024-05-20-third-summer-meeting.md
@@ -7,14 +7,18 @@ tags = ['meeting', 'club-fair', 'goals', 'suggestions']
 +++
 
 ***
+
 # Overview
+
 - Attendance
 - Club Direction
 - Unguided Discussion
 - Next Week
+
 ***
 
 # Attendance
+
 - Jonathan Buckel
 - Lavender Wilson
 - Matthew Williams
@@ -22,30 +26,39 @@ tags = ['meeting', 'club-fair', 'goals', 'suggestions']
 - Paul Shriner
 
 # Club Direction
-We've recently been struggling to retain new members. The current officers seemed to have primarily joined because they were interested in furthering their career and learning things outside of classes, but we think that that approach is not very popular among the majority of students. 
 
-We asked former officers of the club for advice, and they suggested (among many things) that the club should be less formal than we're currently treating it, especially concerning our tendency to have more lecture-type meetings. We greatly appreciate their feedback!
+We've recently been struggling to retain new members. The current officers seemed to have joined because they were interested in furthering their career and learning things outside of classes. However, we think that that approach is not very popular among the majority of students. 
 
-We're considering trying to make club meetings much more friendly/welcoming by greatly reducing the number of presentation meetings (which are rigid and mostly unengaging), and instead encouraging more general discussions and fun activities.
+We asked former officers of the club for advice; their suggestions were extremely helpful and inciteful! We greatly appreciate their feedback!
 
-We also want to broaden the scope of our club, especially focusing on more casual social events. However, we will need to be careful not to spread ourselves out too thin. Regardless, the audience we want to appeal to is a newer and less serious audience than the one we're currently poised for.
+The overall changes we feel need to happen include:
+- Make meetings and the club overall less formal.
+- Reduce the number of presentaton meetings (which are rigid and mostly unengaging), instead encouraging more general discussions and fun activities.
+- Broaden the scope of the club, especially focusing on more casual social events. We will need to be careful not to spread ourselves out too thin. 
+- Appeal to a newer and less serious audience.
 
 # Unguided Discussion
+
 ## Club Fair Preparations
-We aim to start planning for the first club fair in the upcoming semester as soon as possible. We want to have a nice display as well as something to give out; currently, we plan on having stickers with our club logo to give out, but we still need to iron out what exactly we want to put on display. 
+
+We aim to start planning for the first club fair in the upcoming semester soon. We want to have a nice display as well as something to give out (such as stickers with our club logo).
 
 ## First Week of Fall 2024
+
 We also want to focus efforts on spreading word about the club; we think that word of mouth is a good way to get people to consider joining. We plan on communicating with our advisor and professors to see if they would be willing to help us with members. 
 
 ## Flyers
-Printing flyers has worked decently well in the past, but we want to make a new flyer that's simpler. The current design is too complicated and wordy, so we plan on iterating on something to make a more effective flyer. 
+
+Printing flyers has worked decently well in the past, but our current design is too complicated and wordy. We want to make a new flyer that's simpler.
 
 ## Meeting Content/Structure
-Since last semester's content didn't seem very engaging to most students, we want to try doing something different for the majority of our meetings. We still will probably have more serious meetings when we have speakers, but we want a much more casual environment for the majority of our meetings. 
 
-Part of creating a more casual and inviting environment could have the officers actively engaging members and encouraging discussion. While having free discussion is great on paper, it can be too easy for one or two people to take all of the talking space and not leave much room for others to jump in to the conversation. 
+The content last semester didn't seem very engaging to most students, and was often too rigid/serious. We want a much more casual environment for the majority of the meetings (meetings with speakers will probably be more serious). 
+
+To create a more casual and inviting environment, the officers will all need to actively engage members and encourage discussion. If only one or two officers are talking, others may feel they can't jump in the conversation.
 
 # Next Week
-Since Monday next week is Memorial Day, we don't plan on holding a meeting that day. We aren't sure what day would be good, so we'll be posting an announcement as soon as we know the day and time of the next meeting (and we'll announce 1 day before as usual).
 
-For the contents of next week, we want to start with discussing activities we can have during club meetings that are more aimed towards newer/less experienced members, as well as list out the kinds of things that we're passionate about which we could incorporate into meeting topics. 
+We won't have a meeting Monday next week as it's Memorial Day. We'll post an announcement as soon as we know the day and time of the next meeting.
+
+For the contents of next week, we want to start with discussing activities we can have during club meetings that are aimed towards newer/less experienced members, as well as list the things that we're passionate about which we could incorporate into meeting topics. 

--- a/content/posts/2024-05-20-third-summer-meeting.md
+++ b/content/posts/2024-05-20-third-summer-meeting.md
@@ -33,7 +33,7 @@ We asked former officers of the club for advice; their suggestions were extremel
 
 The overall changes we feel need to happen include:
 - Make meetings and the club overall less formal.
-- Reduce the number of presentaton meetings (which are rigid and mostly unengaging), instead encouraging more general discussions and fun activities.
+- Reduce the number of presentation meetings (which are rigid and mostly unengaging), instead encouraging more general discussions and fun activities.
 - Broaden the scope of the club, especially focusing on more casual social events. We will need to be careful not to spread ourselves out too thin. 
 - Appeal to a newer and less serious audience.
 
@@ -59,6 +59,6 @@ To create a more casual and inviting environment, the officers will all need to 
 
 # Next Week
 
-We won't have a meeting Monday next week as it's Memorial Day. We'll post an announcement as soon as we know the day and time of the next meeting.
+We won't have a meeting Monday next week as it's Memorial Day. We'll post the next meeting time on Discord as soon as we can!
 
 For the contents of next week, we want to start with discussing activities we can have during club meetings that are aimed towards newer/less experienced members, as well as list the things that we're passionate about which we could incorporate into meeting topics. 

--- a/content/posts/2024-05-26-fourth-summer-meeting.md
+++ b/content/posts/2024-05-26-fourth-summer-meeting.md
@@ -3,7 +3,7 @@ title = '4th Summer 2024 Meeting'
 date = 2024-05-26T22:13:00-04:00
 draft = false
 summary = 'club direction, gameboy/playdate development'
-tags = ['meeting', 'suggestions', 'retro']
+tags = ['meeting', 'suggestions', 'retro', 'gameboy', 'playdate', 'presentation']
 +++
 
 ***
@@ -29,7 +29,7 @@ tags = ['meeting', 'suggestions', 'retro']
 
 Last meeting, we (the officers) were tasked with brainstorming topics we are passionate about. Here is what we came up with:
 
-* Cyber Security / Privacy
+* Cybersecurity / Privacy
 * Jailbreaking / Rooting
 * JRPG / RPG Maker / Retro Gaming / Retro Computers
 
@@ -64,4 +64,4 @@ This is something the officers (particularly Paul and Matt) will need to work on
 
 For next week, the officers will research Gameboy and Playdate development. We encourage anyone who will be coming next semester to stop by the next meeting to offer your feedback on our ideas.
 
-The meeting day/time will be posted closer to the meeting.
+Watch our Discord for the next meeting time!

--- a/content/posts/2024-05-26-fourth-summer-meeting.md
+++ b/content/posts/2024-05-26-fourth-summer-meeting.md
@@ -7,21 +7,26 @@ tags = ['meeting', 'suggestions', 'retro']
 +++
 
 ***
+
 # Overview
+
 - Attendance
 - Passionate Topics
 - Gameboy/Playdate
 - Presentations
 - Next Week
+
 ***
 
 # Attendance
+
 - Abu Shettima
 - Jonathan Buckel
 - Matthew Williams
 - Paul Shriner
 
 # Passionate Topics
+
 Last meeting, we (the officers) were tasked with brainstorming topics we are passionate about. Here is what we came up with:
 
 * Cyber Security / Privacy
@@ -31,18 +36,32 @@ Last meeting, we (the officers) were tasked with brainstorming topics we are pas
 We decided to focus on retro gaming, as there are many possibilities given by the subject matter. Of course, the other topics could still be good for singular meetings. 
 
 # Gameboy/Playdate
+
 We need to have a target platform for which we'd explore. Jon recommends either the Gameboy or the Playdate (a modern indie handheld console), as both have readily available development resources, unlike other platforms such as the NES or SNES.
 
 With the platform chosen, members can make projects to run on it. We will likely need a couple meetings just to cover the development process, then we can break off into actual project development. This will need more thought, as we don't want meetings to get out of hand (a game can quickly spiral out of control due to feature creep).
 
-The benefits from this are numerous. It's rewarding to build a project from the ground up that can actually run on real hardware. The club could use these projects as a way to advertise (hey how'd you make that cool game? oh just join software dev club!) Finally, a published game would look **great** on a resume!
+The benefits from this are numerous:
 
-More information about the Playdate can be found on their site [here](https://play.date/). The actual unit costs $199, but they offer an officially supported emulator for free. We decided that we would start purely on the emulator, then if interest is high enough, we can buy the real unit.
+- It's rewarding to build a project from the ground up.
+- It helps the club grow through advertising (hey how'd you make that cool game? oh just join software dev club!)
+- A published game would look **great** on a resume!
+
+More information about the Playdate can be found [here](https://play.date/). The actual unit costs $199, but they offer an officially supported emulator for free. We decided that we would start purely on the emulator, then if interest is high enough, we can buy the real unit.
 
 # Presentations
-Jon discussed that you need to be passionate about what you're covering in a presentation, as it will show if you're not. Further, he brought up some bad presentation habits, including being too rigid, too quiet, and not being able to adapt to change. This is something the officers (particularly Paul and Matt) will need to work on. 
 
-As this is a club, it does not need to (and should not be) too professional. It's a good chance to learn and experiment (and as Jon said, embarrass yourself). We can also just ask if there's areas we need to work on, people want to help!
+Jon discussed that you need to be passionate in a presentation, it shows if you're not! Further, he brought up some bad presentation habits, including:
+- Being too rigid (standing in one place like a statue)
+- Being too quiet
+- Not being able to adapt to change (how the audience is reacting)
+
+As this is a club, it should not be too formal/professional. It's a good chance to learn, experiment, and even embarrass yourself. We can also just ask if there's areas we need to work on, people want to help!
+
+This is something the officers (particularly Paul and Matt) will need to work on.
 
 # Next Week
-For next week, the officers will research Gameboy and Playdate development. We encourage anyone who will be coming next semester to stop by the next meeting to offer your feedback on our ideas. The meeting day/time will be posted closer to the meeting.
+
+For next week, the officers will research Gameboy and Playdate development. We encourage anyone who will be coming next semester to stop by the next meeting to offer your feedback on our ideas.
+
+The meeting day/time will be posted closer to the meeting.

--- a/content/posts/2024-06-03-fifth-summer-meeting.md
+++ b/content/posts/2024-06-03-fifth-summer-meeting.md
@@ -11,8 +11,8 @@ tags = ['playdate', 'gameboy', 'meeting', 'retro', 'technologies']
 # Overview
 
 - Attendance
-- Playdate/GameBoy Development
-- Playdate/Lua Resources
+- Playdate/Gameboy Development
+- Playdate and Lua Resources
 - Next Week
 
 ***
@@ -25,14 +25,14 @@ tags = ['playdate', 'gameboy', 'meeting', 'retro', 'technologies']
 - Matthew Williams
 - Paul Shriner
 
-# Playdate/GameBoy Development
+# Playdate/Gameboy Development
 
-For the GameBoy, options include:
+For the Gameboy, options include:
 - Developing in Assembly (ASM) - probably a bad move.
-- Developing in C (particularly the GameBoy Development Kit) - actually does not seem bad.
+- Developing in C (particularly the Gameboy Development Kit) - actually does not seem bad.
 - Developing via a more visual IDE (GBStudio) - could be good due to its ease of access/use.
 
-In general, we think GameBoy could be the harder route to go due to it's older hardware and lower level programming, which would be less accessible to newer members.
+In general, we think Gameboy could be the harder route to go due to it's older hardware and lower level programming, which would be less accessible to newer members.
 
 For the Playdate, options include:
 - Developing in Lua - the primary language on the Playdate.
@@ -40,16 +40,16 @@ For the Playdate, options include:
 
 Overall, it seems the Playdate would be a better interest to the club due to its newer hardware and higher level programming. We found that getting started was much easier than expected, allowing for creating simple games quickly (which could be very exciting for new members).
 
-Now that we've decided to develop something for the PlayDate, we need to brainstorm some smaller projects to work on. Ideas that are simple but buildable upon are the kinds of projects that we want. 
+Now that we've decided to develop something for the Playdate, we need to brainstorm some smaller projects to work on. Ideas that are simple but buildable upon are the kinds of projects that we want. 
 
 Abu shared an interesting idea for a game combining details from trivia games and RPGs. The player would be asked a trivia question and then the correctness of the answer would influence the following RPG section. We also discussed some other kind of retro-styled game, but concluded these ideas were not necessarily the scope that we want.
 
-# PlayDate and Lua Resources
+# Playdate and Lua Resources
 
 - [Lua](https://lua.org/download.html)
 - [VSCode Lua extension](https://marketplace.visualstudio.com/items?itemName=sumneko.lua)
-- [PlayDate SDK](https://play.date/dev/) (includes some example games)
-- [PlayDate reference docs](https://sdk.play.date/2.5.0/Inside%20Playdate.html)
+- [Playdate SDK](https://play.date/dev/) (includes some example games)
+- [Playdate reference docs](https://sdk.play.date/2.5.0/Inside%20Playdate.html)
 - [VSCode Playdate extension](https://marketplace.visualstudio.com/items?itemName=Orta.playdate) (includes a launch.json)
 
 # Next Week
@@ -61,4 +61,4 @@ The officers' assignment is to explore Playdate development and focus on a speci
 - Logic
 - Data Structures
 
-Our next meeting will be on **Monday, June 10th** at **7 PM**. 
+Our next meeting will be on **Monday, June 10th** at **7 PM**, feel free to drop by! 

--- a/content/posts/2024-06-03-fifth-summer-meeting.md
+++ b/content/posts/2024-06-03-fifth-summer-meeting.md
@@ -5,48 +5,60 @@ draft = false
 summary = 'PlayDate and GameBoy research findings, project ideas, development areas'
 tags = ['PlayDate', 'GameBoy', 'meeting', 'retro', 'technologies']
 +++
+
 ***
+
 # Overview
+
 - Attendance
-- Playdate/GameBoy
+- Playdate/GameBoy Development
 - Playdate/Lua Resources
 - Next Week
+
 ***
+
 # Attendance
+
 - Abu Shettima
 - Jonathan Buckel
 - Lavender Wilson
 - Matthew Williams
 - Paul Shriner
+
 # Playdate/GameBoy Development
-We found that there were a few options for GameBoy development, mainly concerning the following: 
-- Developing programs in ASM
-- Developing programs in C (particularly the GameBoy Development Kit)
-- Developing via a more visual IDE (GBStudio)  
 
-We found that jumping straight in (with C) wasn't bad, and thought that going the ASM route would probably be a bad move. We also thought that GBStudio could be a good route due to its ease of access/use as a more visual IDE.  
+For the GameBoy, options include:
+- Developing in Assembly (ASM) - probably a bad move.
+- Developing in C (particularly the GameBoy Development Kit) - actually does not seem bad.
+- Developing via a more visual IDE (GBStudio) - could be good due to its ease of access/use.
 
-For playdate development, it seemed that getting started and using the SDK was much easier than expected, so it may be a good choice that many people can more easily get started with. 
+In general, we think GameBoy could be the harder route to go due to it's older hardware and lower level programming, which would be less accessible to newer members.
 
-Abu shared an idea for a game combining details from trivia games and RPGs, where the player would be asked a trivia question and then the correctness of the answer would influence the following RPG section, which is an interesting idea.  
+For the Playdate, options include:
+- Developing in Lua - the primary language on the Playdate.
+- Developing in C - available for those who are interested in going low level or seeking more performance. C can be used with Lua.
 
-For GameBoy development in general, we think that it could be the harder route to go since the hardware is older, especially considering that a generally lower level route is less accessible to newer members. We think that going the high-level route (the PlayDate route) would be in the better interests for the club as a whole.  
-
-While lua is the primary language for developing things on the PlayDate, C is also available for those who wish to use it, so by going this route we don't necessarily sacrifice the ability to go low-level.  
+Overall, it seems the Playdate would be a better interest to the club due to its newer hardware and higher level programming. We found that getting started was much easier than expected, allowing for creating simple games quickly (which could be very exciting for new members).
 
 Now that we've decided to develop something for the PlayDate, we need to brainstorm some smaller projects to work on. Ideas that are simple but buildable upon are the kinds of projects that we want. 
 
-Here are some ideas that popped up (not necessarily the scope that we want):  
-- Abu's RPG idea (above)
-- Some other kind of retro-styled game
+Abu shared an interesting idea for a game combining details from trivia games and RPGs. The player would be asked a trivia question and then the correctness of the answer would influence the following RPG section. We also discussed some other kind of retro-styled game, but concluded these ideas were not necessarily the scope that we want.
 
 # PlayDate and Lua Resources
+
 - [Lua](https://lua.org/download.html)
 - [VSCode Lua extension](https://marketplace.visualstudio.com/items?itemName=sumneko.lua)
 - [PlayDate SDK](https://play.date/dev/) (includes some example games)
 - [PlayDate reference docs](https://sdk.play.date/2.5.0/Inside%20Playdate.html)
 - [VSCode Playdate extension](https://marketplace.visualstudio.com/items?itemName=Orta.playdate) (includes a launch.json)
-# Next Week
-The officers' assignment is to look further into development for the PlayDate, as well as focusing on a specific area to improve their skills and experience with. The areas to look into included graphics, sound, logic, and data structures.  
 
-For next week, we'll be having a meeting at the same time and day (**Monday, June 10th** at **7 PM**). 
+# Next Week
+
+The officers' assignment is to explore Playdate development and focus on a specific area to improve their skills and experience with. These areas include:
+
+- Graphics
+- Sound
+- Logic
+- Data Structures
+
+Our next meeting will be on **Monday, June 10th** at **7 PM**. 

--- a/content/posts/2024-06-10-sixth-summer-meeting.md
+++ b/content/posts/2024-06-10-sixth-summer-meeting.md
@@ -1,33 +1,57 @@
 +++
-title = '6th Summer Meeting'
+title = '6th Summer 2024 Meeting'
 date = 2024-06-10T20:33:46-04:00
 draft = false
 summary = 'playdate development, advertising'
 tags = ['meeting', 'playdate', 'retro', 'advertising']
 +++
+
 ***
+
 # Overview
+
 - Attendance
 - Playdate Development
-- Club Merchandising
+- Club Advertising/Merchandising
 - Other Discussion
 - Next Week
+
 ***
+
 # Attendance
+
 - Abu Shettima
 - Jonathan Buckel
 - Lavender Wilson
 - Matthew Williams
 - Paul Shriner
+
 # Playdate Development
-We found that there's a pretty nice web tool called [Pulp](https://play.date/pulp/) that is essentially an entire game engine for easily making games for the Playdate. It includes things like a visual tile editor, a scripting portion, a music editor, and some other things. 
-Lavender briefly showed off their progress in the small demo game they're working on, which is a simple music playing game. The project will be made available soon on [their GitHub page](https://github.com/lavender-aa?tab=repositories).
+
+We discovered a useful web tool called [Pulp](https://play.date/pulp/), a game maker for easily creating Playdate games. It includes a visual tile editor, scripting, music editing, and more. 
+
+Lavender briefly showed off their progress on a small demo game (a simple music playing game). The project will be made available soon on [their GitHub page](https://github.com/lavender-aa?tab=repositories).
+
 # Club Advertising/Merchandising
-We had some general discussion surrounding stickers (primarily to give out during club fairs and other events). We think they could be a good idea, but we will need to figure out the details (what to print, how many, estimated cost), likely involving the SAI for help. We think that other merchandising such as apparel or thumb drives could be good as well. 
-If we do decide to do thumb drives, we think that putting stickers on them would probably be the easiest way to customize them at a low cost. 
+
+We discussed some forms of apparel/merchandise for promoting the club (these could be given out during club fairs and events, or possibly sold):
+
+- Stickers - we think they're a good idea, but need to finalize details such as design, quantity, and cost, possibly with SAI's help.
+
+- Flash Drives - customizing them with stickers ourselves seems like a cost-effective approach (compared to using a paid service).
+
 # Other Discussion
-An event like an expo was proposed, but we currently don't have much to show off. Maybe if we get a lot of smaller projects done this semester we could have one next semester, but it'd be a lot of work. 
-We also talked about how having some kind of big event, something like a hackathon (not named that way, since it caused the event not to happen in a previous semester). A good way to get people to come to an event is to advertise free stuff (food works especially well), and then the people who are interested in the club can stay and learn more. 
-We talked about possibly doing something in Natali to garner more attention from people passing by. 
+
+We proposed a couple of event ideas:
+
+- Club Expo - we decided it's not feasible yet. If we get many smaller projects done this semester, we could revisit doing one next semester.
+
+- Hackathon - it would have to be called something else (it caused an event not to happen in a previous semester) but the idea would be similar. 
+
+A good way to attract people to an event is through free stuff (such as food); people who are interested in the club can stay and learn more. 
+
+To further promote the club, we could do something in Natali to grab the attention of passersby. 
+
 # Next Week
-We'll be having a meeting on the same day and time next week (**Monday, June 17th** at **7 PM**). 
+
+Our next meeting will be on **Monday, June 17th** at **7 PM**. 

--- a/content/posts/2024-06-10-sixth-summer-meeting.md
+++ b/content/posts/2024-06-10-sixth-summer-meeting.md
@@ -3,7 +3,7 @@ title = '6th Summer 2024 Meeting'
 date = 2024-06-10T20:33:46-04:00
 draft = false
 summary = 'playdate development, advertising'
-tags = ['meeting', 'playdate', 'retro', 'advertising']
+tags = ['meeting', 'playdate', 'retro', 'advertising', 'merch', 'events']
 +++
 
 ***
@@ -54,4 +54,4 @@ To further promote the club, we could do something in Natali to grab the attenti
 
 # Next Week
 
-Our next meeting will be on **Monday, June 17th** at **7 PM**. 
+Our next meeting will be on **Monday, June 17th** at **7 PM**, feel free to drop by! 

--- a/content/posts/2024-06-17-seventh-summer-meeting.md
+++ b/content/posts/2024-06-17-seventh-summer-meeting.md
@@ -27,15 +27,15 @@ tags = ['meeting', 'playdate', 'project', 'outreach']
 
 # GitHub Webhooks
 
-Paul updated the settings for the GitHub webhook, now the github-updates channel should be less annoying! Any unintended side effects should be reported to him as he has the required permissions on our GitHub organization to fix anything.
+Paul updated the settings for the GitHub webhook, now the github-updates channel should be less annoying! If there's any unintended side effects, report them to the officers!
 
 # Constitution Revisions
 
 Paul shared a OneDrive link to constitution revisions for officers to edit.
 
-Changes include:
+Changes so far:
 - Renamed the club from Programming Club to PennWest Software Development Club 
-- Updated university references from California University to PennWest California
+- Updated university references from California University/Cal U to PennWest California
 - Added general comments
 
 Officers should use the comment feature for changes and add notes on the last page for a collaborative effort.
@@ -84,4 +84,4 @@ We encourage anyone to suggest additional flyer ideas!
 # Next Week
 
 - Discuss the PlayDate club fair project idea with all officers and agree on a direction.
-- We will post the next meeting time on our Discord, feel free to drop by!
+- Be sure to watch the Discord for our next meeting time!

--- a/themes/PaperMod/assets/css/common/post-single.css
+++ b/themes/PaperMod/assets/css/common/post-single.css
@@ -266,7 +266,8 @@
 
 .toc details summary {
     cursor: zoom-in;
-    margin-inline-start: 20px;
+    margin-inline-start: 10px;
+    user-select: none;
 }
 
 .toc details[open] summary {
@@ -279,8 +280,9 @@
 }
 
 .toc .inner {
-    margin: 0 20px;
-    padding: 10px 20px;
+    margin: 5px 20px 0;
+    padding: 0 10px;
+    opacity: 0.9;
 }
 
 .toc li ul {

--- a/themes/PaperMod/i18n/oc.yaml
+++ b/themes/PaperMod/i18n/oc.yaml
@@ -1,0 +1,33 @@
+- id: prev_page
+  translation: "Prec."
+
+- id: next_page
+  translation: "Seg."
+
+- id: read_time
+  translation:
+    one : "1 min"
+    other: "{{ .Count }} min"
+
+- id: words
+  translation:
+    one : "mot"
+    other: "{{ .Count }} motss"
+
+- id: toc
+  translation: "Taula de contengut"
+
+- id: translations
+  translation: "Traduccions"
+
+- id: home
+  translation: "Acuèlh"
+
+- id: edit_post
+  translation: "Modificar"
+
+- id: code_copy
+  translation: "copiar"
+
+- id: code_copied
+  translation: "copiat !"


### PR DESCRIPTION
I cleaned up the 2nd through 6th summer meeting notes a bit. The main issue I noticed is that they were basically a block of text, which is not the easiest to read and could deter someone from reading the notes. I resolved this by breaking up the large chunks of text into smaller sections, as well as using bulleted lists when a list seemed appropriate (the entire notes should not be a bulleted list). 

There were also a few issues of clarity which I attempted to solve (overall, the content was well covered, but a few places did not line up with what actually happened during the meeting). 

I want us to discuss this more (in a future meeting?), but the general gist is that these notes should be a way for people to easily understand what we discussed in meetings. They should not be more lengthy or detailed than needed, and should be clear and easy to understand.

I updated Hugo to 0.127.0.